### PR TITLE
SPLAT-1430: Created alpha build workflow, and added ipam version for template.

### DIFF
--- a/.github/workflows/build-alpha.yml
+++ b/.github/workflows/build-alpha.yml
@@ -1,0 +1,45 @@
+# This workflow will build a golang project
+# For more information see: https://docs.github.com/en/actions/automating-builds-and-tests/building-and-testing-go
+
+name: Build
+on:
+  push:
+    branches: [ "v1alpha1" ]
+jobs:
+  build:
+    runs-on: ubuntu-20.04
+    steps:
+    - name: Checkout Code
+      uses: actions/checkout@v3
+    - name: Set Up Go
+      uses: actions/setup-go@v3
+      with:
+        go-version: 1.20.0
+#    - name: Pull Secret
+#      run: echo '${{ secrets.PULLSECRET }}' > ~/.docker/config.json
+    - name: Go Mod
+      run: go mod vendor
+#    - name: Build
+#      run: go build -v --mod=vendor -ldflags "-X github.com/openshift-splat-team/mapi-static-ip-controller/pkg/version.Raw=${{ vars.GITHUB_REF_NAME }} -X github.com/openshift-splat-team/mapi-static-ip-controller/pkg/version.Commit=${{ vars.GITHUB_SHA }}"  -o "bin/mapi-static-ip-controller" ./cmd/mapi-static-ip-controller
+    - name: Build Image
+      id: build-image
+      uses: redhat-actions/buildah-build@v2.12
+      with:
+        image: machine-ipam-controller
+        tags: v1alpha1 ${{ github.sha }}
+        dockerfiles: ./Dockerfile
+
+    # Podman Login action (https://github.com/redhat-actions/podman-login) also be used to log in,
+    # in which case 'username' and 'password' can be omitted.
+    - name: Push To quay.io
+      id: push-to-quay
+      uses: redhat-actions/push-to-registry@v2
+      with:
+        image: ${{ steps.build-image.outputs.image }}
+        tags: ${{ steps.build-image.outputs.tags }}
+        registry: quay.io/ocp-splat
+        username: ocp-splat+splat_team_push
+        password: ${{ secrets.REGISTRY_PASSWORD }}
+
+    - name: Print image url
+      run: echo "Image pushed to ${{ steps.push-to-quay.outputs.registry-paths }}"

--- a/hack/ci-resources.yaml
+++ b/hack/ci-resources.yaml
@@ -101,7 +101,7 @@ objects:
             k8s-app: machine-ipam-controller
         spec:
           containers:
-            - image: quay.io/ocp-splat/machine-ipam-controller:latest
+            - image: quay.io/ocp-splat/machine-ipam-controller:${IPAM_VERSION}
               imagePullPolicy: Always
               name: machine-ipam-controller
               resources:
@@ -167,3 +167,6 @@ parameters:
     description: The prefix value used in the IPPool spec.
   - name: GATEWAY
     description: The gateway value used in the IPPool spec.
+  - name: IPAM_VERSION
+    description: The version tag to use for the container image.  Default value is "latest".
+    value: latest

--- a/install/0000_30_machine-ipam-controller_09_rbac.yaml
+++ b/install/0000_30_machine-ipam-controller_09_rbac.yaml
@@ -31,20 +31,13 @@ rules:
       - ipaddressclaims
       - ipaddressclaims/status
     verbs:
-      - get
-      - list
-      - patch
-      - watch
+      - "*"
   - apiGroups:
       - ipam.cluster.x-k8s.io
     resources:
       - ipaddresses
     verbs:
-      - create
-      - delete
-      - list
-      - patch
-      - watch
+      - "*"
 ---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding


### PR DESCRIPTION
[SPLAT-1430](https://issues.redhat.com/browse/OCPBUGS-29078)

Note: The SPLAT Jira card was converted into an OCPBUGS-29078

## Changes
- Created new workflow for v1alpha1 so any pushes / merges into it result in a new v1alpha1 version image being generated and published
- Updated template used in CI to allow parameter for specifying the image tag to use for the container

## Dependencies
- https://github.com/openshift/release/pull/48797